### PR TITLE
feat: support 4-15s duration for 4.0/4.0-pro video models

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -433,7 +433,7 @@ A: 可以。现在支持直接上传本地文件。请参考上方的“本地�
 - `duration` (number, 可选): 视频时长（秒）。不同模型支持的值：
   - `jimeng-video-veo3` / `jimeng-video-veo3.1`: `8`（固定）
   - `jimeng-video-sora2`: `4`（默认）、`8`、`12`
-  - `jimeng-video-4.0-pro` / `jimeng-video-4.0`: `5`（默认）、`10`、`15`
+  - `jimeng-video-4.0-pro` / `jimeng-video-4.0`: `4`–`15` 秒任意可选（默认 `5`）
   - `jimeng-video-3.5-pro`: `5`（默认）、`10`、`12`
   - 其他模型: `5`（默认）、`10`
 - `file_paths` (array, 可选): 一个包含图片URL的数组，用于指定视频的**首帧**（数组第1个元素）和**尾帧**（数组第2个元素）。
@@ -447,8 +447,8 @@ A: 可以。现在支持直接上传本地文件。请参考上方的“本地�
 > - **重要**：一旦提供图片输入（图生视频或首尾帧视频），`ratio` 参数将被忽略，视频比例将由输入图片的实际比例决定。`resolution` 参数仍然有效。
 
 **支持的视频模型**:
-- `jimeng-video-4.0-pro` - Seedance 2.0 专业版，仅国内站支持，支持15秒时长 **（最新）**
-- `jimeng-video-4.0` - Seedance 2.0 标准版，仅国内站支持，支持15秒时长 **（最新）**
+- `jimeng-video-4.0-pro` - Seedance 2.0 专业版，仅国内站支持，支持 4–15 秒任意可选 **（最新）**
+- `jimeng-video-4.0` - Seedance 2.0 标准版，仅国内站支持，支持 4–15 秒任意可选 **（最新）**
 - `jimeng-video-3.5-pro` - 专业版v3.5，国内/国际站均支持 **（默认）**
 - `jimeng-video-veo3` - Veo3模型，仅亚洲国际站 (HK/JP/SG) 支持，固定8秒时长
 - `jimeng-video-veo3.1` - Veo3.1模型，仅亚洲国际站 (HK/JP/SG) 支持，固定8秒时长

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Generate a video from a text prompt (Text-to-Video) or from start/end frame imag
 - `duration` (number, optional): Video duration in seconds. Supported values vary by model:
   - `jimeng-video-veo3` / `jimeng-video-veo3.1`: `8` (fixed)
   - `jimeng-video-sora2`: `4` (default), `8`, `12`
-  - `jimeng-video-4.0-pro` / `jimeng-video-4.0`: `5` (default), `10`, `15`
+  - `jimeng-video-4.0-pro` / `jimeng-video-4.0`: `4`–`15` (any integer, default `5`)
   - `jimeng-video-3.5-pro`: `5` (default), `10`, `12`
   - Other models: `5` (default), `10`
 - `file_paths` (array, optional): An array of image URLs to specify the **start frame** (1st element) and **end frame** (2nd element) of the video.
@@ -426,8 +426,8 @@ Generate a video from a text prompt (Text-to-Video) or from start/end frame imag
 > - **Important**: Once image input is provided (image-to-video or first-last frame video), the `ratio` parameter will be ignored, and the video aspect ratio will be determined by the input image's actual ratio. The `resolution` parameter remains effective.
 
 **Supported Video Models**:
-- `jimeng-video-4.0-pro` - Seedance 2.0 Professional Edition, China site only, supports 15s duration **(Latest)**
-- `jimeng-video-4.0` - Seedance 2.0 Standard Edition, China site only, supports 15s duration **(Latest)**
+- `jimeng-video-4.0-pro` - Seedance 2.0 Professional Edition, China site only, supports 4–15s duration (any value) **(Latest)**
+- `jimeng-video-4.0` - Seedance 2.0 Standard Edition, China site only, supports 4–15s duration (any value) **(Latest)**
 - `jimeng-video-3.5-pro` - Professional Edition v3.5, works on all sites **(Default)**
 - `jimeng-video-veo3` - Veo3 model, Asia international sites only (HK/JP/SG), fixed 8s duration
 - `jimeng-video-veo3.1` - Veo3.1 model, Asia international sites only (HK/JP/SG), fixed 8s duration

--- a/src/api/controllers/videos.ts
+++ b/src/api/controllers/videos.ts
@@ -124,6 +124,7 @@ export async function generateVideo(
   const isVeo3 = model.includes("veo3");
   const isSora2 = model.includes("sora2");
   const is35Pro = model.includes("3.5_pro");
+  const is40 = model.includes("seedance_40"); // 4.0 / 4.0-pro，支持 4-15s 任意可选
   // 只有 video-3.0 和 video-3.0-fast 支持 resolution 参数（3.0-pro 和 3.5-pro 不支持）
   const supportsResolution = (model.includes("vgfm_3.0") || model.includes("vgfm_3.0_fast")) && !model.includes("_pro");
 
@@ -131,6 +132,7 @@ export async function generateVideo(
   // veo3 模型固定 8 秒
   // sora2 模型支持 4秒、8秒、12秒，默认4秒
   // 3.5-pro 模型支持 5秒、10秒、12秒，默认5秒
+  // 4.0/4.0-pro 模型支持 4-15秒 任意可选，默认5秒
   // 其他模型支持 5秒、10秒，默认5秒
   let durationMs: number;
   let actualDuration: number;
@@ -159,6 +161,10 @@ export async function generateVideo(
       durationMs = 5000;
       actualDuration = 5;
     }
+  } else if (is40) {
+    const clamped = Math.min(15, Math.max(4, Math.round(Number(duration))));
+    durationMs = clamped * 1000;
+    actualDuration = clamped;
   } else {
     durationMs = duration === 10 ? 10000 : 5000;
     actualDuration = duration === 10 ? 10 : 5;

--- a/src/api/routes/videos.ts
+++ b/src/api/routes/videos.ts
@@ -23,8 +23,8 @@ export default {
                 .validate('body.resolution', v => _.isUndefined(v) || _.isString(v))
                 .validate('body.duration', v => {
                     if (_.isUndefined(v)) return true;
-                    // 支持的时长: 4/8/12 (sora2)、5/10 (其他模型)、15 (4.0模型)
-                    const validDurations = [4, 5, 8, 10, 12, 15];
+                    // 支持的时长: 4-15 (4.0/4.0-pro 任意可选)、4/8/12 (sora2)、5/10/12 (3.5-pro 等)
+                    const validDurations = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
                     // 对于 multipart/form-data，允许字符串类型的数字
                     if (isMultiPart && typeof v === 'string') {
                         const num = parseInt(v);


### PR DESCRIPTION
问题：当我使用jimeng-video-4.0-pro生成15s视频时，我发现会自动重置为5s视频，且根据文档显示仅有5、10、15时长选择。
解决：目前官方支持4-15s任意选择，在更新代码后，已测试验证通过。如果项目目前还没有此计划，可暂时忽略此项合并。