### PR TITLE
feat(api): 增加异步生图与视频生成端点

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -582,6 +582,43 @@ curl -X POST http://localhost:5100/v1/videos/generations \
 
 ```
 
+### 异步任务 API
+
+对于生成时间较长（特别是视频）的请求，建议使用异步 API 避免连接超时。提交任务后立即返回 `task_id`，你可以随时查询任务进度和最终结果。
+
+> **内置复古前端台**：在浏览器打开 `http://localhost:5100/index.html` 即可体验开箱即用的 Windows 2000 风格异步任务管理界面！
+
+**1. 提交异步任务**
+
+请求参数与原同步接口**完全一致**。
+- **POST** `/v1/async/images/generations` (文生图)
+- **POST** `/v1/async/images/compositions` (图生图)
+- **POST** `/v1/async/videos/generations` (视频生成)
+
+**响应示例**（立即返回）：
+```json
+{
+  "task_id": "a1b2c3d4-...",
+  "status": "pending",
+  "type": "video_generation",
+  "created_at": 1770981920,
+  "poll_url": "/v1/async/tasks/a1b2c3d4-..."
+}
+```
+
+**2. 查询单个任务进度**
+
+- **GET** `/v1/async/tasks/:task_id`
+
+返回包含 `status` (pending | processing | completed | failed)、`progress` (0-100) 以及 `result` 或 `error`。
+
+**3. 列出所有任务**
+
+- **GET** `/v1/async/tasks`
+
+支持可选查询参数 `?status=pending|processing|completed|failed` 进行过滤。
+返回 `tasks` 数组和 `stats` 统计信息。
+
 ### Token API
 
 #### Token 绑定代理功能 (新)

--- a/README.md
+++ b/README.md
@@ -551,6 +551,43 @@ curl -X POST http://localhost:5100/v1/videos/generations \
 
 ```
 
+### Async Task API
+
+For requests that take a long time to generate (especially videos), it is recommended to use the Async API to avoid connection timeouts. A `task_id` is returned immediately after submission, and you can query the task progress and final results at any time.
+
+> **Built-in Retro Frontend**: Open `http://localhost:5100/index.html` in your browser to experience an out-of-the-box Windows 2000 style async task management interface!
+
+**1. Submit Async Task**
+
+Request parameters are **exactly the same** as the original synchronous API.
+- **POST** `/v1/async/images/generations` (Text-to-Image)
+- **POST** `/v1/async/images/compositions` (Image-to-Image)
+- **POST** `/v1/async/videos/generations` (Video Generation)
+
+**Response Example** (Returns immediately):
+```json
+{
+  "task_id": "a1b2c3d4-...",
+  "status": "pending",
+  "type": "video_generation",
+  "created_at": 1770981920,
+  "poll_url": "/v1/async/tasks/a1b2c3d4-..."
+}
+```
+
+**2. Query Single Task Progress**
+
+- **GET** `/v1/async/tasks/:task_id`
+
+Returns `status` (pending | processing | completed | failed), `progress` (0-100), and `result` or `error`.
+
+**3. List All Tasks**
+
+- **GET** `/v1/async/tasks`
+
+Supports optional query parameter `?status=pending|processing|completed|failed` for filtering.
+Returns `tasks` array and `stats` information.
+
 ### Token API
 
 #### Token Bound Proxy Feature (New)

--- a/src/api/routes/async-tasks.ts
+++ b/src/api/routes/async-tasks.ts
@@ -1,0 +1,367 @@
+import fs from 'fs';
+import _ from 'lodash';
+
+import Request from '@/lib/request/Request.ts';
+import { generateImages, generateImageComposition } from '@/api/controllers/images.ts';
+import { generateVideo, DEFAULT_MODEL as DEFAULT_VIDEO_MODEL } from '@/api/controllers/videos.ts';
+import { DEFAULT_IMAGE_MODEL } from '@/api/consts/common.ts';
+import { tokenSplit } from '@/api/controllers/core.ts';
+import taskManager, { TaskStatus } from '@/lib/task-manager.ts';
+import util from '@/lib/util.ts';
+import logger from '@/lib/logger.ts';
+
+export default {
+  prefix: '/v1/async',
+
+  post: {
+    /**
+     * 异步文生图
+     *
+     * POST /v1/async/images/generations
+     * 立即返回 task_id，通过 GET /v1/tasks/:task_id 查询结果
+     */
+    '/images/generations': async (request: Request) => {
+      request
+        .validate('body.model', v => _.isUndefined(v) || _.isString(v))
+        .validate('body.prompt', _.isString)
+        .validate('body.negative_prompt', v => _.isUndefined(v) || _.isString(v))
+        .validate('body.ratio', v => _.isUndefined(v) || _.isString(v))
+        .validate('body.resolution', v => _.isUndefined(v) || _.isString(v))
+        .validate('body.intelligent_ratio', v => _.isUndefined(v) || _.isBoolean(v))
+        .validate('body.sample_strength', v => _.isUndefined(v) || _.isFinite(v))
+        .validate('body.response_format', v => _.isUndefined(v) || _.isString(v))
+        .validate('headers.authorization', _.isString);
+
+      const tokens = tokenSplit(request.headers.authorization);
+      const token = _.sample(tokens);
+      const {
+        model,
+        prompt,
+        negative_prompt: negativePrompt,
+        ratio,
+        resolution,
+        intelligent_ratio: intelligentRatio,
+        sample_strength: sampleStrength,
+        response_format,
+      } = request.body;
+
+      const finalModel = _.defaultTo(model, DEFAULT_IMAGE_MODEL);
+      const responseFormat = _.defaultTo(response_format, 'url');
+
+      const task = taskManager.create(
+        'image_generation',
+        async () => {
+          const imageUrls = await generateImages(finalModel, prompt, {
+            ratio,
+            resolution,
+            sampleStrength,
+            negativePrompt,
+            intelligentRatio,
+          }, token);
+
+          let data;
+          if (responseFormat === 'b64_json') {
+            data = (
+              await Promise.all(imageUrls.map(url => util.fetchFileBASE64(url)))
+            ).map(b64 => ({ b64_json: b64 }));
+          } else {
+            data = imageUrls.map(url => ({ url }));
+          }
+
+          return { created: util.unixTimestamp(), data };
+        },
+        { model: finalModel, prompt, ratio, resolution }
+      );
+
+      return {
+        task_id: task.task_id,
+        status: task.status,
+        type: task.type,
+        created_at: task.created_at,
+        poll_url: `/v1/tasks/${task.task_id}`,
+      };
+    },
+
+    /**
+     * 异步图生图
+     *
+     * POST /v1/async/images/compositions
+     */
+    '/images/compositions': async (request: Request) => {
+      const contentType = request.headers['content-type'] || '';
+      const isMultiPart = contentType.startsWith('multipart/form-data');
+
+      if (isMultiPart) {
+        request
+          .validate('body.model', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.prompt', _.isString)
+          .validate('body.negative_prompt', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.ratio', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.resolution', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.intelligent_ratio', v => _.isUndefined(v) || (typeof v === 'string' && (v === 'true' || v === 'false')) || _.isBoolean(v))
+          .validate('body.sample_strength', v => _.isUndefined(v) || (typeof v === 'string' && !isNaN(parseFloat(v))) || _.isFinite(v))
+          .validate('body.response_format', v => _.isUndefined(v) || _.isString(v))
+          .validate('headers.authorization', _.isString);
+      } else {
+        request
+          .validate('body.model', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.prompt', _.isString)
+          .validate('body.images', _.isArray)
+          .validate('body.negative_prompt', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.ratio', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.resolution', v => _.isUndefined(v) || _.isString(v))
+          .validate('body.intelligent_ratio', v => _.isUndefined(v) || _.isBoolean(v))
+          .validate('body.sample_strength', v => _.isUndefined(v) || _.isFinite(v))
+          .validate('body.response_format', v => _.isUndefined(v) || _.isString(v))
+          .validate('headers.authorization', _.isString);
+      }
+
+      // 解析图片数据（必须在主线程做，因为临时文件可能被清理）
+      let images: (string | Buffer)[] = [];
+      if (isMultiPart) {
+        const files = (request.files as any)?.images;
+        if (!files) throw new Error("在form-data中缺少 'images' 字段");
+        const imageFiles = Array.isArray(files) ? files : [files];
+        if (imageFiles.length === 0) throw new Error('至少需要提供1张输入图片');
+        if (imageFiles.length > 10) throw new Error('最多支持10张输入图片');
+        images = imageFiles.map(file => fs.readFileSync(file.filepath));
+      } else {
+        const bodyImages = request.body.images;
+        if (!bodyImages || bodyImages.length === 0) throw new Error('至少需要提供1张输入图片');
+        if (bodyImages.length > 10) throw new Error('最多支持10张输入图片');
+        bodyImages.forEach((image: any, index: number) => {
+          if (!_.isString(image) && !_.isObject(image)) {
+            throw new Error(`图片 ${index + 1} 格式不正确`);
+          }
+          if (_.isObject(image) && !(image as any).url) {
+            throw new Error(`图片 ${index + 1} 缺少url字段`);
+          }
+        });
+        images = bodyImages.map((image: any) => _.isString(image) ? image : image.url);
+      }
+
+      const tokens = tokenSplit(request.headers.authorization);
+      const token = _.sample(tokens);
+      const {
+        model,
+        prompt,
+        negative_prompt: negativePrompt,
+        ratio,
+        resolution,
+        intelligent_ratio: intelligentRatio,
+        sample_strength: sampleStrength,
+        response_format,
+      } = request.body;
+
+      const finalModel = _.defaultTo(model, DEFAULT_IMAGE_MODEL);
+      const finalSampleStrength = isMultiPart && typeof sampleStrength === 'string'
+        ? parseFloat(sampleStrength) : sampleStrength;
+      const finalIntelligentRatio = isMultiPart && typeof intelligentRatio === 'string'
+        ? intelligentRatio === 'true' : intelligentRatio;
+      const responseFormat = _.defaultTo(response_format, 'url');
+
+      const task = taskManager.create(
+        'image_composition',
+        async () => {
+          const resultUrls = await generateImageComposition(finalModel, prompt, images, {
+            ratio,
+            resolution,
+            sampleStrength: finalSampleStrength,
+            negativePrompt,
+            intelligentRatio: finalIntelligentRatio,
+          }, token);
+
+          let data;
+          if (responseFormat === 'b64_json') {
+            data = (
+              await Promise.all(resultUrls.map(url => util.fetchFileBASE64(url)))
+            ).map(b64 => ({ b64_json: b64 }));
+          } else {
+            data = resultUrls.map(url => ({ url }));
+    }
+
+          return {
+            created: util.unixTimestamp(),
+            data,
+            input_images: images.length,
+            composition_type: 'multi_image_synthesis',
+          };
+        },
+        { model: finalModel, prompt, ratio, resolution, imageCount: images.length }
+      );
+
+      return {
+        task_id: task.task_id,
+        status: task.status,
+        type: task.type,
+        created_at: task.created_at,
+        poll_url: `/v1/tasks/${task.task_id}`,
+      };
+    },
+
+    /**
+     * 异步视频生成
+     *
+     * POST /v1/async/videos/generations
+     */
+    '/videos/generations': async (request: Request) => {
+      const contentType = request.headers['content-type'] || '';
+      const isMultiPart = contentType.startsWith('multipart/form-data');
+
+      request
+        .validate('body.model', v => _.isUndefined(v) || _.isString(v))
+        .validate('body.prompt', _.isString)
+        .validate('body.ratio', v => _.isUndefined(v) || _.isString(v))
+        .validate('body.resolution', v => _.isUndefined(v) || _.isString(v))
+        .validate('body.functionMode', v => _.isUndefined(v) || (_.isString(v) && ['first_last_frames', 'omni_reference'].includes(v)))
+        .validate('body.response_format', v => _.isUndefined(v) || _.isString(v))
+        .validate('headers.authorization', _.isString);
+
+      const functionMode = request.body.functionMode || 'first_last_frames';
+
+      // duration 验证（复用现有逻辑）
+      if (!_.isUndefined(request.body.duration)) {
+        const modelName = request.body.model || DEFAULT_VIDEO_MODEL;
+        let durationValue: number;
+        if (isMultiPart && typeof request.body.duration === 'string') {
+          durationValue = parseInt(request.body.duration, 10);
+          if (!Number.isInteger(durationValue) || request.body.duration.trim() !== String(durationValue)) {
+            throw new Error(`duration 必须是整数，当前值: ${request.body.duration}`);
+          }
+        } else if (_.isFinite(request.body.duration)) {
+          durationValue = request.body.duration as number;
+          if (!Number.isInteger(durationValue)) {
+            throw new Error(`duration 必须是整数，当前值: ${durationValue}`);
+          }
+        } else {
+          throw new Error('duration 参数格式错误');
+        }
+
+        let validDurations: number[] = [];
+        let errorMessage = '';
+        if (modelName.includes('veo3.1') || modelName.includes('veo3')) {
+          validDurations = [8];
+          errorMessage = 'veo3 模型仅支持 8 秒时长';
+        } else if (modelName.includes('sora2')) {
+          validDurations = [4, 8, 12];
+          errorMessage = 'sora2 模型仅支持 4、8、12 秒时长';
+        } else if (modelName.includes('3.5-pro') || modelName.includes('3.5_pro')) {
+          validDurations = [5, 10, 12];
+          errorMessage = '3.5-pro 模型仅支持 5、10、12 秒时长';
+        } else if (modelName.includes('seedance-2.0') || modelName.includes('40_pro') || modelName.includes('40-pro') || modelName.includes('seedance-2.0-fast')) {
+          if (durationValue < 4 || durationValue > 15) {
+            throw new Error(`seedance 2.0/2.0-fast 模型支持 4~15 秒时长，当前值: ${durationValue}`);
+          }
+        } else {
+          validDurations = [5, 10];
+          errorMessage = '该模型仅支持 5、10 秒时长';
+        }
+        if (validDurations.length > 0 && !validDurations.includes(durationValue)) {
+          throw new Error(`${errorMessage}，当前值: ${durationValue}`);
+        }
+      }
+
+      request
+        .validate('body.file_paths', v => _.isUndefined(v) || (_.isArray(v) && v.length <= 2))
+        .validate('body.filePaths', v => _.isUndefined(v) || (_.isArray(v) && v.length <= 2));
+
+      const tokens = tokenSplit(request.headers.authorization);
+      const token = _.sample(tokens);
+
+      const {
+        model = DEFAULT_VIDEO_MODEL,
+        prompt,
+        ratio = '1:1',
+        resolution = '720p',
+        duration = 5,
+        file_paths = [],
+        filePaths = [],
+        response_format = 'url',
+      } = request.body;
+
+      const finalDuration = isMultiPart && typeof duration === 'string'
+        ? parseInt(duration) : duration;
+      const finalFilePaths = filePaths.length > 0 ? filePaths : file_paths;
+
+      // 注意：对于 multipart 上传的文件，需要在主线程里拿到 files 引用
+      const files = request.files;
+      const httpRequest = request;
+
+      const task = taskManager.create(
+        'video_generation',
+        async () => {
+          const generatedVideoUrl = await generateVideo(
+            model,
+            prompt,
+            {
+              ratio,
+              resolution,
+              duration: finalDuration,
+              filePaths: finalFilePaths,
+              files,
+              httpRequest,
+              functionMode,
+            },
+            token
+          );
+
+          if (response_format === 'b64_json') {
+            const videoBase64 = await util.fetchFileBASE64(generatedVideoUrl);
+            return {
+              created: util.unixTimestamp(),
+              data: [{ b64_json: videoBase64, revised_prompt: prompt }],
+            };
+          } else {
+            return {
+              created: util.unixTimestamp(),
+              data: [{ url: generatedVideoUrl, revised_prompt: prompt }],
+            };
+          }
+        },
+        { model, prompt, ratio, resolution, duration: finalDuration }
+      );
+
+      return {
+        task_id: task.task_id,
+        status: task.status,
+        type: task.type,
+        created_at: task.created_at,
+        poll_url: `/v1/tasks/${task.task_id}`,
+      };
+    },
+  },
+
+  get: {
+    /**
+     * 查询单个任务状态
+     *
+     * GET /v1/async/tasks/:task_id
+     */
+    '/tasks/:task_id': async (request: Request) => {
+      const taskId = request.params.task_id;
+      const task = taskManager.get(taskId);
+
+      if (!task) {
+        throw new Error(`任务不存在: ${taskId}`);
+      }
+
+      return task;
+    },
+
+    /**
+     * 列出所有任务
+     *
+     * GET /v1/async/tasks?status=pending|processing|completed|failed
+     */
+    '/tasks': async (request: Request) => {
+      const status = request.query?.status as TaskStatus | undefined;
+      const tasks = taskManager.list(status);
+      const stats = taskManager.stats();
+
+      return {
+        tasks,
+        stats,
+      };
+    },
+  },
+};

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -4,6 +4,7 @@ import ping from "./ping.ts";
 import token from './token.js';
 import models from './models.ts';
 import videos from './videos.ts';
+import asyncTasks from './async-tasks.ts';
 
 export default [
     {
@@ -19,6 +20,11 @@ export default [
                         images: '/v1/images/generations',
                         compositions: '/v1/images/compositions',
                         videos: '/v1/videos/generations',
+                        async_images: '/v1/async/images/generations',
+                        async_compositions: '/v1/async/images/compositions',
+                        async_videos: '/v1/async/videos/generations',
+                        tasks: '/v1/async/tasks',
+                        task_detail: '/v1/async/tasks/:task_id',
                         models: '/v1/models',
                         health: '/ping'
                     }
@@ -30,5 +36,6 @@ export default [
     ping,
     token,
     models,
-    videos
+    videos,
+    asyncTasks
 ];

--- a/src/lib/task-manager.ts
+++ b/src/lib/task-manager.ts
@@ -1,0 +1,183 @@
+import { v4 as uuidv4 } from 'uuid';
+import logger from './logger.ts';
+
+/**
+ * 任务状态枚举
+ */
+export type TaskStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+/**
+ * 任务类型枚举
+ */
+export type TaskType = 'image_generation' | 'image_composition' | 'video_generation';
+
+/**
+ * 任务接口
+ */
+export interface Task {
+  /** 任务唯一 ID */
+  task_id: string;
+  /** 任务类型 */
+  type: TaskType;
+  /** 任务状态 */
+  status: TaskStatus;
+  /** 进度百分比 (0-100) */
+  progress: number;
+  /** 创建时间 (unix timestamp) */
+  created_at: number;
+  /** 更新时间 (unix timestamp) */
+  updated_at: number;
+  /** 完成时间 (unix timestamp, 可选) */
+  completed_at?: number;
+  /** 任务结果 (完成后填充) */
+  result?: any;
+  /** 错误信息 (失败后填充) */
+  error?: string;
+  /** 原始请求参数 (用于回溯) */
+  params?: any;
+}
+
+/**
+ * 任务管理器 - 内存存储 + 后台执行
+ *
+ * 提供异步任务的创建、查询、清理功能。
+ * 任务存储在内存中，进程重启后丢失。
+ */
+class TaskManager {
+  /** 任务存储 Map */
+  private tasks: Map<string, Task> = new Map();
+
+  /** 已完成任务的最大保留时间 (毫秒)，默认 2 小时 */
+  private readonly COMPLETED_TTL = 2 * 60 * 60 * 1000;
+
+  /** 清理定时器间隔 (毫秒)，默认 10 分钟 */
+  private readonly CLEANUP_INTERVAL = 10 * 60 * 1000;
+
+  constructor() {
+    // 定时清理过期任务
+    setInterval(() => this.cleanup(), this.CLEANUP_INTERVAL);
+    logger.info('TaskManager initialized');
+  }
+
+  /**
+   * 创建新任务并立即在后台执行
+   *
+   * @param type 任务类型
+   * @param executor 实际执行函数，返回结果
+   * @param params 原始请求参数（可选，用于回溯）
+   * @returns 创建的任务信息（不含 result）
+   */
+  create(type: TaskType, executor: () => Promise<any>, params?: any): Task {
+    const now = Math.floor(Date.now() / 1000);
+    const task: Task = {
+      task_id: uuidv4(),
+      type,
+      status: 'pending',
+      progress: 0,
+      created_at: now,
+      updated_at: now,
+      params,
+    };
+
+    this.tasks.set(task.task_id, task);
+    logger.info(`Task created: ${task.task_id} (${type})`);
+
+    // 后台执行，不阻塞返回
+    this.execute(task.task_id, executor);
+
+    return { ...task };
+  }
+
+  /**
+   * 查询任务
+   */
+  get(taskId: string): Task | undefined {
+    const task = this.tasks.get(taskId);
+    return task ? { ...task } : undefined;
+  }
+
+  /**
+   * 列出所有任务（可按状态过滤）
+   */
+  list(status?: TaskStatus): Task[] {
+    const tasks = Array.from(this.tasks.values());
+    const filtered = status ? tasks.filter(t => t.status === status) : tasks;
+    return filtered
+      .sort((a, b) => b.created_at - a.created_at)
+      .map(t => ({ ...t }));
+  }
+
+  /**
+   * 获取统计信息
+   */
+  stats(): { total: number; pending: number; processing: number; completed: number; failed: number } {
+    const tasks = Array.from(this.tasks.values());
+    return {
+      total: tasks.length,
+      pending: tasks.filter(t => t.status === 'pending').length,
+      processing: tasks.filter(t => t.status === 'processing').length,
+      completed: tasks.filter(t => t.status === 'completed').length,
+      failed: tasks.filter(t => t.status === 'failed').length,
+    };
+  }
+
+  /**
+   * 后台执行任务
+   */
+  private async execute(taskId: string, executor: () => Promise<any>): Promise<void> {
+    const task = this.tasks.get(taskId);
+    if (!task) return;
+
+    // 更新为 processing
+    task.status = 'processing';
+    task.progress = 10;
+    task.updated_at = Math.floor(Date.now() / 1000);
+
+    logger.info(`Task started: ${taskId}`);
+
+    try {
+      const result = await executor();
+
+      // 成功
+      task.status = 'completed';
+      task.progress = 100;
+      task.result = result;
+      task.completed_at = Math.floor(Date.now() / 1000);
+      task.updated_at = task.completed_at;
+
+      const elapsed = task.completed_at - task.created_at;
+      logger.info(`Task completed: ${taskId}, elapsed: ${elapsed}s`);
+    } catch (error: any) {
+      // 失败
+      task.status = 'failed';
+      task.error = error.message || 'Unknown error';
+      task.updated_at = Math.floor(Date.now() / 1000);
+
+      logger.error(`Task failed: ${taskId}, error: ${task.error}`);
+    }
+  }
+
+  /**
+   * 清理过期的已完成/已失败任务
+   */
+  private cleanup(): void {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [taskId, task] of this.tasks) {
+      if (task.status === 'completed' || task.status === 'failed') {
+        const taskAge = now - task.updated_at * 1000;
+        if (taskAge > this.COMPLETED_TTL) {
+          this.tasks.delete(taskId);
+          cleaned++;
+        }
+      }
+    }
+
+    if (cleaned > 0) {
+      logger.info(`TaskManager cleanup: removed ${cleaned} expired tasks, ${this.tasks.size} remaining`);
+    }
+  }
+}
+
+export default new TaskManager();


### PR DESCRIPTION
## 改动
- 增加 `src/lib/task-manager.ts` 实现基于内存的异步任务队列和状态轮询
- 增加 `POST /v1/async/images/generations` 等非阻塞端点
- 增加 `GET /v1/async/tasks` 查询任务状态接口
- 更新 README 文档说明

## 原因
长视频生成耗时可达 20 分钟，同步接口可能会导致代理或者应用客户端由于请求时间过长被意外阻断连接。

## 关联
- 无

---

✨ **附注 (Bonus)**: 
如果需要一个现成的图形界面来管理和预览这些异步任务，我写了一个纯前端的 Windows 2000 风格单文件 Web UI，支持 IndexedDB 离线媒体缓存和多 Token 积分查询。你可以直接通过下面的在线网页使用它，无需任何安装配置：

🌐 **在线体验 (Live Demo)**: [https://moeblack.github.io/jimeng-async-ui/](https://moeblack.github.io/jimeng-async-ui/)  
📦 **前端源码 (Source Code)**: [Moeblack/jimeng-async-ui](https://github.com/Moeblack/jimeng-async-ui)