### PR TITLE
Add batch colorize UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,6 @@ tmp/
 temp/
 jimeng-*.md
 scripts/
+!scripts/
+!scripts/batch-colorize.mjs
 .ace-tool/

--- a/BATCH_COLORIZE.md
+++ b/BATCH_COLORIZE.md
@@ -1,0 +1,83 @@
+# 批量图生图上色
+
+本项目新增了一个批量客户端脚本，用于读取文件夹中的图片，并按顺序调用本地 `jimeng-api` 的图生图接口完成上色。
+
+## 启动 API 服务
+
+先确保 `jimeng-api` 服务正在运行：
+
+```bash
+npm install
+npm run build
+npm run start
+```
+
+默认接口地址为 `http://localhost:5100`。
+
+## 批量处理
+
+### 使用 UI
+
+启动服务后，在浏览器打开：
+
+```text
+http://localhost:5100/batch-colorize
+```
+
+在页面中填写输入文件夹、输出文件夹、Session ID、提示词和模型参数，点击“开始上色”。任务会在页面右侧显示进度、队列状态和日志。
+
+支持两种目录方式：
+
+- 点击“选择”按钮选择输入/输出目录：浏览器会直接读取输入目录图片，并把结果写入选择的输出目录。
+- 手动输入本机路径：由服务端按路径读取和保存，适合作为目录选择不可用时的兜底。
+
+浏览器目录选择需要 Chromium 系浏览器支持 File System Access API；`localhost` 页面可直接使用。
+
+### 使用命令行
+
+```bash
+npm run batch:colorize -- --input ./input-images --output ./colored-images --token YOUR_SESSION_ID
+```
+
+也可以使用环境变量保存 sessionid：
+
+```bash
+$env:JIMENG_SESSION_ID="YOUR_SESSION_ID"
+npm run batch:colorize -- --input ./input-images --output ./colored-images
+```
+
+国际站 token 按原项目规则添加地区前缀，例如 `us-YOUR_SESSION_ID`、`hk-YOUR_SESSION_ID`、`jp-YOUR_SESSION_ID`、`sg-YOUR_SESSION_ID`。
+
+## 常用参数
+
+- `--input <dir>`：输入图片文件夹，必填。
+- `--output <dir>`：输出文件夹，默认是 `<input>/colorized`。
+- `--token <sessionid>`：即梦 sessionid，也可用 `JIMENG_SESSION_ID`。
+- `--api <url>`：API 地址，默认 `http://localhost:5100`。
+- `--prompt <text>`：上色提示词。
+- `--model <name>`：模型，默认 `jimeng-4.5`。
+- `--ratio <ratio>`：输出比例，默认 `1:1`。
+- `--resolution <level>`：分辨率，默认 `2k`。
+- `--sample-strength <number>`：图生图强度，默认 `0.5`。
+- `--negative-prompt <text>`：负面提示词。
+- `--intelligent-ratio`：启用智能比例。
+- `--recursive`：递归读取子目录。
+- `--overwrite`：覆盖已存在输出文件。
+- `--delay <ms>`：每张图片之间等待的毫秒数。
+- `--continue-on-error <bool>`：单张失败后是否继续，默认 `true`。
+
+## 示例
+
+递归处理线稿目录，并降低请求频率：
+
+```bash
+npm run batch:colorize -- --input ./linearts --output ./colored --recursive --delay 3000 --token us-YOUR_SESSION_ID
+```
+
+指定更明确的上色提示词：
+
+```bash
+npm run batch:colorize -- --input ./input --output ./output --token YOUR_SESSION_ID --prompt "为黑白漫画线稿上色，保持线条清晰，色彩自然，人物肤色和服装层次丰富"
+```
+
+脚本会把生成结果保存为 `原文件名_colorized.webp`，并在输出目录写入 `batch-colorize-report.json`。

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN npm ci --omit=dev --registry https://registry.npmmirror.com/ && \
 # 从构建阶段复制构建产物
 COPY --from=builder --chown=jimeng:nodejs /app/dist ./dist
 COPY --from=builder --chown=jimeng:nodejs /app/configs ./configs
+COPY --from=builder --chown=jimeng:nodejs /app/public ./public
 
 # 创建应用需要的目录并设置权限
 RUN mkdir -p /app/logs /app/tmp && \

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "tsup src/index.ts --format cjs,esm --sourcemap --dts --watch --onSuccess \"node --enable-source-maps --no-node-snapshot dist/index.js\"",
     "start": "node --enable-source-maps --no-node-snapshot dist/index.js",
+    "batch:colorize": "node scripts/batch-colorize.mjs",
     "build": "tsup src/index.ts --format cjs,esm --sourcemap --dts --clean",
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write \"src/**/*.{ts,js,json}\"",

--- a/public/batch-colorize.html
+++ b/public/batch-colorize.html
@@ -1,0 +1,1117 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>批量上色</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --surface: #ffffff;
+      --surface-2: #eef2f5;
+      --line: #d8dee5;
+      --text: #19212a;
+      --muted: #697582;
+      --accent: #16856a;
+      --accent-2: #b85b2c;
+      --danger: #b42318;
+      --ok: #087443;
+      --warn: #ad6b00;
+      --shadow: 0 10px 30px rgba(27, 39, 51, 0.08);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+    }
+
+    button,
+    input,
+    select,
+    textarea {
+      font: inherit;
+    }
+
+    .app {
+      display: grid;
+      grid-template-columns: minmax(340px, 440px) minmax(0, 1fr);
+      min-height: 100vh;
+    }
+
+    .sidebar {
+      border-right: 1px solid var(--line);
+      background: var(--surface);
+      padding: 24px;
+      overflow: auto;
+    }
+
+    .workspace {
+      padding: 24px;
+      overflow: auto;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 22px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 24px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin: 0 0 14px;
+      font-size: 16px;
+      line-height: 1.35;
+      letter-spacing: 0;
+    }
+
+    .status-pill {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      color: var(--muted);
+      font-size: 12px;
+      padding: 5px 10px;
+      white-space: nowrap;
+    }
+
+    .form {
+      display: grid;
+      gap: 16px;
+    }
+
+    .field {
+      display: grid;
+      gap: 7px;
+    }
+
+    .field-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+
+    .picker-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 8px;
+    }
+
+    .picker-row button {
+      white-space: nowrap;
+    }
+
+    label {
+      color: #344054;
+      font-size: 13px;
+      font-weight: 650;
+    }
+
+    input,
+    select,
+    textarea {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #fff;
+      color: var(--text);
+      padding: 10px 11px;
+      outline: none;
+      transition: border-color 160ms ease, box-shadow 160ms ease;
+    }
+
+    textarea {
+      min-height: 112px;
+      resize: vertical;
+      line-height: 1.45;
+    }
+
+    input:focus,
+    select:focus,
+    textarea:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(22, 133, 106, 0.15);
+    }
+
+    .toggles {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+    }
+
+    .toggle {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 10px;
+      background: #fff;
+      min-height: 42px;
+    }
+
+    .toggle input {
+      width: 16px;
+      height: 16px;
+      accent-color: var(--accent);
+      padding: 0;
+    }
+
+    .actions {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 10px;
+      margin-top: 4px;
+    }
+
+    button {
+      border: 1px solid transparent;
+      border-radius: 6px;
+      min-height: 42px;
+      padding: 9px 14px;
+      cursor: pointer;
+      font-weight: 700;
+      transition: transform 120ms ease, background-color 120ms ease, border-color 120ms ease;
+    }
+
+    button:active {
+      transform: translateY(1px);
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.62;
+    }
+
+    .primary {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .secondary {
+      background: #fff;
+      border-color: var(--line);
+      color: var(--text);
+    }
+
+    .danger {
+      background: #fff;
+      border-color: #f0b8b3;
+      color: var(--danger);
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(120px, 1fr));
+      gap: 12px;
+      margin-bottom: 18px;
+    }
+
+    .metric {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      box-shadow: var(--shadow);
+    }
+
+    .metric span {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      margin-bottom: 6px;
+    }
+
+    .metric strong {
+      font-size: 24px;
+      line-height: 1;
+    }
+
+    .progress-wrap {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 18px;
+      box-shadow: var(--shadow);
+    }
+
+    .progress-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      margin-bottom: 10px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .bar {
+      height: 12px;
+      overflow: hidden;
+      border-radius: 999px;
+      background: var(--surface-2);
+    }
+
+    .bar div {
+      width: 0%;
+      height: 100%;
+      background: linear-gradient(90deg, var(--accent), #4f9d46);
+      transition: width 220ms ease;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+      gap: 18px;
+      align-items: start;
+    }
+
+    .panel {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      border-bottom: 1px solid var(--line);
+      padding: 14px 16px;
+    }
+
+    .table-wrap {
+      overflow: auto;
+      max-height: 520px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 720px;
+    }
+
+    th,
+    td {
+      border-bottom: 1px solid var(--line);
+      padding: 10px 12px;
+      text-align: left;
+      vertical-align: top;
+      font-size: 13px;
+    }
+
+    th {
+      background: #fbfcfd;
+      color: #475467;
+      font-size: 12px;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    td.path {
+      max-width: 360px;
+      word-break: break-all;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
+      border-radius: 999px;
+      padding: 3px 9px;
+      font-size: 12px;
+      font-weight: 700;
+      background: var(--surface-2);
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    .success {
+      background: #e6f4ed;
+      color: var(--ok);
+    }
+
+    .failed {
+      background: #fdecea;
+      color: var(--danger);
+    }
+
+    .running {
+      background: #fff2d6;
+      color: var(--warn);
+    }
+
+    .skipped {
+      background: #edf1f7;
+      color: #43546a;
+    }
+
+    .logs {
+      height: 520px;
+      overflow: auto;
+      margin: 0;
+      padding: 14px 16px;
+      background: #111820;
+      color: #d7e1ea;
+      font-family: "Cascadia Mono", Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.55;
+      white-space: pre-wrap;
+    }
+
+    .empty {
+      color: var(--muted);
+      padding: 36px 16px;
+      text-align: center;
+    }
+
+    .message {
+      min-height: 22px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .message.error {
+      color: var(--danger);
+    }
+
+    @media (max-width: 1040px) {
+      .app,
+      .grid {
+        grid-template-columns: 1fr;
+      }
+
+      .sidebar {
+        border-right: 0;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .summary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 620px) {
+      .sidebar,
+      .workspace {
+        padding: 16px;
+      }
+
+      .field-row,
+      .toggles,
+      .actions {
+        grid-template-columns: 1fr;
+      }
+
+      .summary {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="app">
+    <aside class="sidebar">
+      <div class="brand">
+        <h1>批量上色</h1>
+        <span class="status-pill" id="connection">就绪</span>
+      </div>
+
+      <form class="form" id="jobForm">
+        <div class="field">
+          <label for="inputDir">输入文件夹</label>
+          <div class="picker-row">
+            <input id="inputDir" name="inputDir" placeholder="E:\Project\JMAI\input-images">
+            <button class="secondary" id="selectInputButton" type="button">选择</button>
+          </div>
+        </div>
+
+        <div class="field">
+          <label for="outputDir">输出文件夹</label>
+          <div class="picker-row">
+            <input id="outputDir" name="outputDir" placeholder="E:\Project\JMAI\colored-images">
+            <button class="secondary" id="selectOutputButton" type="button">选择</button>
+          </div>
+        </div>
+
+        <div class="field">
+          <label for="token">Session ID</label>
+          <input id="token" name="token" type="password" autocomplete="off" required>
+        </div>
+
+        <div class="field">
+          <label for="prompt">提示词</label>
+          <textarea id="prompt" name="prompt">请为这张图片进行专业上色，保持原始构图、线条、人物和细节不变，补充自然协调的色彩、光影和材质，画面干净，高质量。</textarea>
+        </div>
+
+        <div class="field-row">
+          <div class="field">
+            <label for="model">模型</label>
+            <select id="model" name="model">
+              <option value="jimeng-4.5">jimeng-4.5</option>
+              <option value="jimeng-5.0">jimeng-5.0</option>
+              <option value="jimeng-4.6">jimeng-4.6</option>
+              <option value="jimeng-4.1">jimeng-4.1</option>
+              <option value="jimeng-4.0">jimeng-4.0</option>
+              <option value="nanobananapro">nanobananapro</option>
+              <option value="nanobanana">nanobanana</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="resolution">分辨率</label>
+            <select id="resolution" name="resolution">
+              <option value="1k">1k</option>
+              <option value="2k" selected>2k</option>
+              <option value="4k">4k</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="field-row">
+          <div class="field">
+            <label for="ratio">比例</label>
+            <select id="ratio" name="ratio">
+              <option value="1:1">1:1</option>
+              <option value="4:3">4:3</option>
+              <option value="3:4">3:4</option>
+              <option value="16:9">16:9</option>
+              <option value="9:16">9:16</option>
+              <option value="3:2">3:2</option>
+              <option value="2:3">2:3</option>
+              <option value="21:9">21:9</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="sampleStrength">图生图强度</label>
+            <input id="sampleStrength" name="sampleStrength" type="number" min="0" max="1" step="0.05" value="0.5">
+          </div>
+        </div>
+
+        <div class="field">
+          <label for="negativePrompt">负面提示词</label>
+          <input id="negativePrompt" name="negativePrompt">
+        </div>
+
+        <div class="toggles">
+          <label class="toggle"><input name="recursive" type="checkbox">递归子目录</label>
+          <label class="toggle"><input name="overwrite" type="checkbox">覆盖结果</label>
+          <label class="toggle"><input name="intelligentRatio" type="checkbox">智能比例</label>
+          <label class="toggle"><input name="continueOnError" type="checkbox" checked>失败后继续</label>
+        </div>
+
+        <div class="field-row">
+          <div class="field">
+            <label for="delayMs">间隔毫秒</label>
+            <input id="delayMs" name="delayMs" type="number" min="0" step="500" value="0">
+          </div>
+        </div>
+
+        <div class="actions">
+          <button class="primary" id="startButton" type="submit">开始上色</button>
+          <button class="danger" id="cancelButton" type="button" disabled>停止</button>
+        </div>
+
+        <div class="message" id="message"></div>
+      </form>
+    </aside>
+
+    <section class="workspace">
+      <section class="summary">
+        <div class="metric"><span>总数</span><strong id="total">0</strong></div>
+        <div class="metric"><span>当前</span><strong id="current">0</strong></div>
+        <div class="metric"><span>成功</span><strong id="success">0</strong></div>
+        <div class="metric"><span>失败</span><strong id="failed">0</strong></div>
+        <div class="metric"><span>跳过</span><strong id="skipped">0</strong></div>
+      </section>
+
+      <section class="progress-wrap">
+        <div class="progress-head">
+          <span id="jobTitle">没有正在运行的任务</span>
+          <span id="percent">0%</span>
+        </div>
+        <div class="bar"><div id="bar"></div></div>
+      </section>
+
+      <section class="grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h2>图片队列</h2>
+            <button class="secondary" id="refreshButton" type="button">刷新</button>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>状态</th>
+                  <th>输入</th>
+                  <th>输出</th>
+                  <th>错误</th>
+                </tr>
+              </thead>
+              <tbody id="items">
+                <tr><td class="empty" colspan="4">等待任务</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>日志</h2>
+            <span class="status-pill" id="jobStatus">idle</span>
+          </div>
+          <pre class="logs" id="logs"></pre>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <script>
+    const form = document.getElementById("jobForm");
+    const message = document.getElementById("message");
+    const startButton = document.getElementById("startButton");
+    const cancelButton = document.getElementById("cancelButton");
+    const refreshButton = document.getElementById("refreshButton");
+    const selectInputButton = document.getElementById("selectInputButton");
+    const selectOutputButton = document.getElementById("selectOutputButton");
+    const connection = document.getElementById("connection");
+    const jobStatus = document.getElementById("jobStatus");
+    const jobTitle = document.getElementById("jobTitle");
+    const logs = document.getElementById("logs");
+    const items = document.getElementById("items");
+    const bar = document.getElementById("bar");
+    const percent = document.getElementById("percent");
+    const metrics = {
+      total: document.getElementById("total"),
+      current: document.getElementById("current"),
+      success: document.getElementById("success"),
+      failed: document.getElementById("failed"),
+      skipped: document.getElementById("skipped"),
+    };
+
+    let activeJobId = localStorage.getItem("batchColorizeJobId") || "";
+    let pollTimer = null;
+    let inputDirectoryHandle = null;
+    let outputDirectoryHandle = null;
+    let selectedFiles = [];
+    let cancelRequested = false;
+
+    if (activeJobId) {
+      pollJob();
+      startPolling();
+    }
+
+    selectInputButton.addEventListener("click", async () => {
+      clearMessage();
+      try {
+        if (!supportsDirectoryPicker()) {
+          const directory = await chooseServerDirectory("选择输入文件夹");
+          inputDirectoryHandle = null;
+          selectedFiles = [];
+          form.inputDir.value = directory;
+          form.inputDir.dataset.picker = "server";
+          message.textContent = `已选择输入目录: ${directory}`;
+          return;
+        }
+
+        inputDirectoryHandle = await window.showDirectoryPicker({ mode: "read" });
+        selectedFiles = await collectImageFiles(inputDirectoryHandle, form.recursive.checked);
+        form.inputDir.value = `${inputDirectoryHandle.name} (${selectedFiles.length} 张图片)`;
+        form.inputDir.dataset.picker = "browser";
+        renderLocalJob({
+          id: "",
+          status: "ready",
+          outputLabel: outputDirectoryHandle ? outputDirectoryHandle.name : "",
+          total: selectedFiles.length,
+          current: 0,
+          success: 0,
+          failed: 0,
+          skipped: 0,
+          logs: [`已选择输入目录: ${inputDirectoryHandle.name}`, `找到 ${selectedFiles.length} 张图片。`],
+          items: selectedFiles.map((entry) => ({
+            input: entry.relativePath,
+            status: "queued",
+            outputs: [],
+            error: "",
+          })),
+        });
+      } catch (error) {
+        showError(error.message);
+      }
+    });
+
+    selectOutputButton.addEventListener("click", async () => {
+      clearMessage();
+      try {
+        if (!supportsDirectoryPicker()) {
+          const directory = await chooseServerDirectory("选择输出文件夹");
+          outputDirectoryHandle = null;
+          form.outputDir.value = directory;
+          form.outputDir.dataset.picker = "server";
+          message.textContent = `已选择输出目录: ${directory}`;
+          return;
+        }
+
+        outputDirectoryHandle = await window.showDirectoryPicker({ mode: "readwrite" });
+        form.outputDir.value = outputDirectoryHandle.name;
+        form.outputDir.dataset.picker = "browser";
+        message.textContent = `已选择输出目录: ${outputDirectoryHandle.name}`;
+      } catch (error) {
+        showError(error.message);
+      }
+    });
+
+    form.recursive.addEventListener("change", async () => {
+      if (!inputDirectoryHandle) return;
+      selectedFiles = await collectImageFiles(inputDirectoryHandle, form.recursive.checked);
+      form.inputDir.value = `${inputDirectoryHandle.name} (${selectedFiles.length} 张图片)`;
+      metrics.total.textContent = selectedFiles.length;
+    });
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearMessage();
+      startButton.disabled = true;
+
+      try {
+        if (inputDirectoryHandle || outputDirectoryHandle) {
+          await runBrowserBatch();
+          return;
+        }
+
+        const body = readForm();
+        const response = await fetch("/v1/batch-colorize/jobs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const data = await parseResponse(response);
+        activeJobId = data.id;
+        localStorage.setItem("batchColorizeJobId", activeJobId);
+        renderJob(data);
+        startPolling();
+      } catch (error) {
+        showError(error.message);
+      } finally {
+        startButton.disabled = false;
+      }
+    });
+
+    cancelButton.addEventListener("click", async () => {
+      if (!activeJobId) {
+        cancelRequested = true;
+        cancelButton.disabled = true;
+        return;
+      }
+      cancelButton.disabled = true;
+      try {
+        const response = await fetch(`/v1/batch-colorize/jobs/${activeJobId}/cancel`, { method: "POST" });
+        const data = await parseResponse(response);
+        renderJob(data);
+      } catch (error) {
+        showError(error.message);
+      }
+    });
+
+    refreshButton.addEventListener("click", () => {
+      if (activeJobId) pollJob();
+    });
+
+    const imageExtensions = new Set([".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif", ".tif", ".tiff"]);
+
+    async function runBrowserBatch() {
+      if (!inputDirectoryHandle) {
+        throw new Error("请先点击输入文件夹旁边的“选择”。");
+      }
+      if (!outputDirectoryHandle) {
+        throw new Error("请先点击输出文件夹旁边的“选择”。");
+      }
+
+      const settings = readForm();
+      if (!settings.token) {
+        throw new Error("请填写 Session ID。");
+      }
+
+      activeJobId = "";
+      localStorage.removeItem("batchColorizeJobId");
+      cancelRequested = false;
+      cancelButton.disabled = false;
+
+      const rows = selectedFiles.map((entry) => ({
+        input: entry.relativePath,
+        status: "queued",
+        outputs: [],
+        error: "",
+      }));
+      const localJob = {
+        id: "browser-directory",
+        status: "running",
+        outputLabel: outputDirectoryHandle.name,
+        total: rows.length,
+        current: 0,
+        success: 0,
+        failed: 0,
+        skipped: 0,
+        logs: [`开始处理 ${rows.length} 张图片。`],
+        items: rows,
+      };
+
+      renderLocalJob(localJob);
+
+      for (let index = 0; index < selectedFiles.length; index += 1) {
+        if (cancelRequested) {
+          localJob.status = "cancelled";
+          localJob.logs.push("任务已停止。");
+          break;
+        }
+
+        const entry = selectedFiles[index];
+        const row = localJob.items[index];
+        localJob.current = index + 1;
+        row.status = "running";
+        localJob.logs.push(`[${localJob.current}/${localJob.total}] 开始处理 ${entry.relativePath}`);
+        renderLocalJob(localJob);
+
+        try {
+          const plannedName = buildOutputName(entry.relativePath, ".webp", 0);
+          if (!settings.overwrite && await outputExists(outputDirectoryHandle, plannedName)) {
+            row.status = "skipped";
+            row.outputs = [plannedName];
+            localJob.skipped += 1;
+            localJob.logs.push(`跳过已存在结果: ${plannedName}`);
+            renderLocalJob(localJob);
+            continue;
+          }
+
+          const urls = await generateFromSelectedFile(entry.file, settings);
+          row.outputs = [];
+          for (let resultIndex = 0; resultIndex < urls.length; resultIndex += 1) {
+            const outputName = buildOutputName(entry.relativePath, getExtensionFromUrl(urls[resultIndex]) || ".webp", resultIndex);
+            await writeUrlToDirectory(outputDirectoryHandle, outputName, urls[resultIndex]);
+            row.outputs.push(outputName);
+          }
+
+          row.status = "success";
+          localJob.success += 1;
+          localJob.logs.push(`完成 ${entry.relativePath}`);
+        } catch (error) {
+          row.status = "failed";
+          row.error = error.message;
+          localJob.failed += 1;
+          localJob.logs.push(`失败 ${entry.relativePath}: ${error.message}`);
+          if (!settings.continueOnError) {
+            localJob.status = "failed";
+            break;
+          }
+        }
+
+        renderLocalJob(localJob);
+
+        if (settings.delayMs > 0 && index < selectedFiles.length - 1) {
+          await sleep(settings.delayMs);
+        }
+      }
+
+      if (localJob.status === "running") {
+        localJob.status = localJob.failed > 0 ? "failed" : "completed";
+      }
+
+      localJob.logs.push("批处理结束。");
+      renderLocalJob(localJob);
+      cancelButton.disabled = true;
+    }
+
+    async function generateFromSelectedFile(file, settings) {
+      const formData = new FormData();
+      formData.append("prompt", settings.prompt);
+      formData.append("model", settings.model);
+      formData.append("ratio", settings.ratio);
+      formData.append("resolution", settings.resolution);
+      formData.append("sample_strength", String(settings.sampleStrength));
+      formData.append("response_format", "url");
+      formData.append("images", file, file.name);
+
+      if (settings.negativePrompt) {
+        formData.append("negative_prompt", settings.negativePrompt);
+      }
+      if (settings.intelligentRatio) {
+        formData.append("intelligent_ratio", "true");
+      }
+
+      const response = await fetch("/v1/images/compositions", {
+        method: "POST",
+        headers: {
+          Authorization: settings.token.toLowerCase().startsWith("bearer ")
+            ? settings.token
+            : `Bearer ${settings.token}`,
+        },
+        body: formData,
+      });
+      const data = await parseResponse(response);
+      const urls = (data.data || []).map((item) => item.url).filter(Boolean);
+      if (urls.length === 0) {
+        throw new Error("接口未返回图片 URL。");
+      }
+      return urls;
+    }
+
+    async function writeUrlToDirectory(rootHandle, relativePath, url) {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`下载生成图片失败: HTTP ${response.status}`);
+      }
+      const fileHandle = await getOutputFileHandle(rootHandle, relativePath, true);
+      const writable = await fileHandle.createWritable();
+      await writable.write(await response.blob());
+      await writable.close();
+    }
+
+    async function outputExists(rootHandle, relativePath) {
+      try {
+        await getOutputFileHandle(rootHandle, relativePath, false);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    async function getOutputFileHandle(rootHandle, relativePath, create) {
+      const parts = normalizeRelativePath(relativePath).split("/");
+      const fileName = parts.pop();
+      let current = rootHandle;
+      for (const part of parts) {
+        current = await current.getDirectoryHandle(part, { create });
+      }
+      return await current.getFileHandle(fileName, { create });
+    }
+
+    async function collectImageFiles(directoryHandle, recursive, prefix = "") {
+      const files = [];
+      for await (const [name, handle] of directoryHandle.entries()) {
+        const relativePath = prefix ? `${prefix}/${name}` : name;
+        if (handle.kind === "directory") {
+          if (recursive) {
+            files.push(...await collectImageFiles(handle, true, relativePath));
+          }
+          continue;
+        }
+
+        if (handle.kind === "file" && imageExtensions.has(getPathExtension(name))) {
+          files.push({
+            file: await handle.getFile(),
+            relativePath,
+          });
+        }
+      }
+
+      return files.sort((a, b) => a.relativePath.localeCompare(b.relativePath, "zh-Hans-CN"));
+    }
+
+    function renderLocalJob(job) {
+      renderJob({
+        id: job.id,
+        status: job.status,
+        options: { outputDir: job.outputLabel || "" },
+        total: job.total,
+        current: job.current,
+        success: job.success,
+        failed: job.failed,
+        skipped: job.skipped,
+        logs: job.logs,
+        items: job.items,
+      });
+    }
+
+    function buildOutputName(relativePath, extension, resultIndex) {
+      const normalized = normalizeRelativePath(relativePath);
+      const slashIndex = normalized.lastIndexOf("/");
+      const dir = slashIndex >= 0 ? normalized.slice(0, slashIndex + 1) : "";
+      const fileName = slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+      const dotIndex = fileName.lastIndexOf(".");
+      const baseName = dotIndex >= 0 ? fileName.slice(0, dotIndex) : fileName;
+      const suffix = resultIndex === 0 ? "" : `_${String(resultIndex + 1).padStart(2, "0")}`;
+      return `${dir}${baseName}_colorized${suffix}${extension}`;
+    }
+
+    function getExtensionFromUrl(value) {
+      try {
+        return getPathExtension(new URL(value).pathname);
+      } catch {
+        return "";
+      }
+    }
+
+    function getPathExtension(value) {
+      const clean = String(value).split("?")[0].toLowerCase();
+      const index = clean.lastIndexOf(".");
+      return index >= 0 ? clean.slice(index) : "";
+    }
+
+    function normalizeRelativePath(value) {
+      return String(value).replaceAll("\\", "/").replace(/^\/+/, "");
+    }
+
+    function supportsDirectoryPicker() {
+      return "showDirectoryPicker" in window;
+    }
+
+    async function chooseServerDirectory(title) {
+      const response = await fetch("/v1/batch-colorize/select-directory", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title }),
+      });
+      const data = await parseResponse(response);
+      return data.directory;
+    }
+
+    function sleep(ms) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    async function pollJob() {
+      if (!activeJobId) return;
+      try {
+        const response = await fetch(`/v1/batch-colorize/jobs/${activeJobId}`);
+        const data = await parseResponse(response);
+        renderJob(data);
+        connection.textContent = "已连接";
+      } catch (error) {
+        connection.textContent = "连接失败";
+        showError(error.message);
+        stopPolling();
+      }
+    }
+
+    function startPolling() {
+      stopPolling();
+      pollTimer = setInterval(pollJob, 2500);
+    }
+
+    function stopPolling() {
+      if (pollTimer) clearInterval(pollTimer);
+      pollTimer = null;
+    }
+
+    function readForm() {
+      const data = new FormData(form);
+      return {
+        inputDir: data.get("inputDir").trim(),
+        outputDir: data.get("outputDir").trim(),
+        token: data.get("token").trim(),
+        prompt: data.get("prompt").trim(),
+        model: data.get("model"),
+        ratio: data.get("ratio"),
+        resolution: data.get("resolution"),
+        sampleStrength: Number(data.get("sampleStrength")),
+        negativePrompt: data.get("negativePrompt").trim(),
+        recursive: data.get("recursive") === "on",
+        overwrite: data.get("overwrite") === "on",
+        intelligentRatio: data.get("intelligentRatio") === "on",
+        continueOnError: data.get("continueOnError") === "on",
+        delayMs: Number(data.get("delayMs") || 0),
+      };
+    }
+
+    async function parseResponse(response) {
+      const data = await response.json();
+      if (!response.ok || data.code && data.code !== 0) {
+        throw new Error(data.message || `HTTP ${response.status}`);
+      }
+      return data;
+    }
+
+    function renderJob(job) {
+      const done = job.status === "completed" || job.status === "failed" || job.status === "cancelled";
+      const progress = job.total ? Math.round((job.current / job.total) * 100) : 0;
+
+      metrics.total.textContent = job.total || 0;
+      metrics.current.textContent = job.current || 0;
+      metrics.success.textContent = job.success || 0;
+      metrics.failed.textContent = job.failed || 0;
+      metrics.skipped.textContent = job.skipped || 0;
+      jobStatus.textContent = job.status || "idle";
+      jobTitle.textContent = job.id ? `${job.id} · ${job.options.outputDir}` : "没有正在运行的任务";
+      percent.textContent = `${progress}%`;
+      bar.style.width = `${progress}%`;
+      logs.textContent = (job.logs || []).join("\n");
+      logs.scrollTop = logs.scrollHeight;
+      cancelButton.disabled = done || !job.id;
+
+      renderItems(job.items || []);
+
+      if (done) {
+        stopPolling();
+      }
+    }
+
+    function renderItems(rows) {
+      if (!rows.length) {
+        items.innerHTML = '<tr><td class="empty" colspan="4">等待任务</td></tr>';
+        return;
+      }
+
+      items.innerHTML = rows.map((item) => {
+        const statusClass = item.status === "success"
+          ? "success"
+          : item.status === "failed"
+            ? "failed"
+            : item.status === "running"
+              ? "running"
+              : item.status === "skipped"
+                ? "skipped"
+                : "";
+
+        return `
+          <tr>
+            <td><span class="badge ${statusClass}">${escapeHtml(item.status)}</span></td>
+            <td class="path">${escapeHtml(item.input)}</td>
+            <td class="path">${escapeHtml((item.outputs || []).join("\\n"))}</td>
+            <td class="path">${escapeHtml(item.error || "")}</td>
+          </tr>
+        `;
+      }).join("");
+    }
+
+    function showError(text) {
+      message.textContent = text;
+      message.classList.add("error");
+    }
+
+    function clearMessage() {
+      message.textContent = "";
+      message.classList.remove("error");
+    }
+
+    function escapeHtml(value) {
+      return String(value ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+    }
+  </script>
+</body>
+</html>

--- a/scripts/batch-colorize.mjs
+++ b/scripts/batch-colorize.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const IMAGE_EXTENSIONS = new Set([
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".bmp",
+  ".gif",
+  ".tif",
+  ".tiff",
+]);
+
+const MIME_TYPES = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".gif": "image/gif",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+};
+
+const DEFAULT_PROMPT =
+  "请为这张图片进行专业上色，保持原始构图、线条、人物和细节不变，补充自然协调的色彩、光影和材质，画面干净，高质量。";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help || args.h) {
+  printHelp();
+  process.exit(0);
+}
+
+const inputDir = path.resolve(requiredArg(args.input ?? args.i, "input"));
+const outputDir = path.resolve(args.output ?? args.o ?? path.join(inputDir, "colorized"));
+const apiBase = trimTrailingSlash(args.api ?? process.env.JIMENG_API_BASE ?? "http://localhost:5100");
+const token = args.token ?? process.env.JIMENG_SESSION_ID ?? process.env.JIMENG_API_TOKEN;
+const model = args.model ?? "jimeng-4.5";
+const prompt = args.prompt ?? DEFAULT_PROMPT;
+const ratio = args.ratio ?? "1:1";
+const resolution = args.resolution ?? "2k";
+const sampleStrength = args["sample-strength"] ?? args.sampleStrength ?? "0.5";
+const negativePrompt = args["negative-prompt"] ?? args.negativePrompt;
+const intelligentRatio = parseBoolean(args["intelligent-ratio"] ?? args.intelligentRatio);
+const recursive = parseBoolean(args.recursive);
+const overwrite = parseBoolean(args.overwrite);
+const continueOnError = parseBoolean(args["continue-on-error"] ?? args.continueOnError, true);
+const delayMs = Number(args.delay ?? 0);
+
+if (!token) {
+  fail("缺少 session token。请通过 --token 传入，或设置 JIMENG_SESSION_ID 环境变量。");
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const imageFiles = await listImages(inputDir, recursive);
+if (imageFiles.length === 0) {
+  fail(`输入目录中没有找到图片: ${inputDir}`);
+}
+
+console.log(`输入目录: ${inputDir}`);
+console.log(`输出目录: ${outputDir}`);
+console.log(`接口地址: ${apiBase}/v1/images/compositions`);
+console.log(`待处理图片: ${imageFiles.length} 张`);
+
+const results = [];
+for (let index = 0; index < imageFiles.length; index += 1) {
+  const filePath = imageFiles[index];
+  const label = `[${index + 1}/${imageFiles.length}] ${path.basename(filePath)}`;
+
+  try {
+    console.log(`${label} 开始上色...`);
+    const generatedUrls = await colorizeImage(filePath);
+    const savedFiles = [];
+
+    for (let resultIndex = 0; resultIndex < generatedUrls.length; resultIndex += 1) {
+      const outputPath = await buildOutputPath(filePath, generatedUrls[resultIndex], resultIndex);
+      if (!overwrite && await exists(outputPath)) {
+        console.log(`${label} 跳过已存在文件: ${outputPath}`);
+        savedFiles.push(outputPath);
+        continue;
+      }
+
+      await downloadFile(generatedUrls[resultIndex], outputPath);
+      savedFiles.push(outputPath);
+    }
+
+    results.push({
+      input: filePath,
+      status: "success",
+      urls: generatedUrls,
+      outputs: savedFiles,
+    });
+    console.log(`${label} 完成，保存 ${savedFiles.length} 个结果。`);
+  } catch (error) {
+    results.push({
+      input: filePath,
+      status: "failed",
+      error: error.message,
+    });
+    console.error(`${label} 失败: ${error.message}`);
+
+    if (!continueOnError) {
+      break;
+    }
+  }
+
+  if (delayMs > 0 && index < imageFiles.length - 1) {
+    await sleep(delayMs);
+  }
+}
+
+const reportPath = path.join(outputDir, "batch-colorize-report.json");
+await writeFile(reportPath, JSON.stringify({
+  createdAt: new Date().toISOString(),
+  inputDir,
+  outputDir,
+  apiBase,
+  model,
+  prompt,
+  ratio,
+  resolution,
+  sampleStrength: Number(sampleStrength),
+  intelligentRatio,
+  total: results.length,
+  success: results.filter((item) => item.status === "success").length,
+  failed: results.filter((item) => item.status === "failed").length,
+  results,
+}, null, 2), "utf8");
+
+console.log(`批处理结束。报告: ${reportPath}`);
+
+async function colorizeImage(filePath) {
+  const buffer = await readFile(filePath);
+  const extension = path.extname(filePath).toLowerCase();
+  const form = new FormData();
+
+  form.append("prompt", prompt);
+  form.append("model", model);
+  form.append("ratio", ratio);
+  form.append("resolution", resolution);
+  form.append("sample_strength", String(sampleStrength));
+  form.append("response_format", "url");
+  form.append("images", new Blob([buffer], {
+    type: MIME_TYPES[extension] ?? "application/octet-stream",
+  }), path.basename(filePath));
+
+  if (negativePrompt) {
+    form.append("negative_prompt", negativePrompt);
+  }
+
+  if (typeof intelligentRatio === "boolean") {
+    form.append("intelligent_ratio", String(intelligentRatio));
+  }
+
+  const response = await fetch(`${apiBase}/v1/images/compositions`, {
+    method: "POST",
+    headers: {
+      Authorization: formatAuthorization(token),
+    },
+    body: form,
+  });
+
+  const bodyText = await response.text();
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    throw new Error(`接口返回非 JSON 内容，HTTP ${response.status}: ${bodyText.slice(0, 300)}`);
+  }
+
+  if (!response.ok || body.code && body.code !== 0) {
+    throw new Error(body.message ?? `接口请求失败，HTTP ${response.status}`);
+  }
+
+  const urls = extractUrls(body);
+  if (urls.length === 0) {
+    throw new Error(`接口未返回图片 URL: ${JSON.stringify(body).slice(0, 500)}`);
+  }
+
+  return urls;
+}
+
+async function listImages(dir, includeSubdirs) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (isSameOrInside(fullPath, outputDir)) {
+        continue;
+      }
+      if (includeSubdirs) {
+        files.push(...await listImages(fullPath, true));
+      }
+      continue;
+    }
+
+    if (entry.isFile() && IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      files.push(fullPath);
+    }
+  }
+
+  return files.sort((a, b) => a.localeCompare(b, "zh-Hans-CN"));
+}
+
+async function buildOutputPath(inputPath, url, resultIndex) {
+  const relativeInput = path.relative(inputDir, inputPath);
+  const parsed = path.parse(relativeInput);
+  const resultSuffix = resultIndex === 0 ? "" : `_${String(resultIndex + 1).padStart(2, "0")}`;
+  const remoteExt = getExtensionFromUrl(url) || ".webp";
+  const targetDir = path.join(outputDir, parsed.dir);
+
+  await mkdir(targetDir, { recursive: true });
+  return path.join(targetDir, `${parsed.name}_colorized${resultSuffix}${remoteExt}`);
+}
+
+async function downloadFile(url, outputPath) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`下载生成图片失败，HTTP ${response.status}: ${url}`);
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  await writeFile(outputPath, bytes);
+}
+
+function extractUrls(body) {
+  const data = Array.isArray(body.data) ? body.data : [];
+  return data
+    .map((item) => item?.url)
+    .filter((url) => typeof url === "string" && url.length > 0);
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+
+    const equalsIndex = arg.indexOf("=");
+    const rawKey = equalsIndex === -1 ? arg.slice(2) : arg.slice(2, equalsIndex);
+    const inlineValue = equalsIndex === -1 ? undefined : arg.slice(equalsIndex + 1);
+    if (!rawKey) {
+      continue;
+    }
+
+    if (inlineValue !== undefined) {
+      parsed[rawKey] = inlineValue;
+      continue;
+    }
+
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[rawKey] = true;
+      continue;
+    }
+
+    parsed[rawKey] = next;
+    i += 1;
+  }
+
+  return parsed;
+}
+
+function parseBoolean(value, defaultValue = undefined) {
+  if (value === undefined) return defaultValue;
+  if (typeof value === "boolean") return value;
+  return ["1", "true", "yes", "y", "on"].includes(String(value).toLowerCase());
+}
+
+function formatAuthorization(value) {
+  return value.toLowerCase().startsWith("bearer ") ? value : `Bearer ${value}`;
+}
+
+function getExtensionFromUrl(value) {
+  try {
+    const pathname = new URL(value).pathname;
+    const ext = path.extname(pathname).toLowerCase();
+    return ext && ext.length <= 6 ? ext : "";
+  } catch {
+    return "";
+  }
+}
+
+function isSameOrInside(candidate, parent) {
+  const relative = path.relative(path.resolve(parent), path.resolve(candidate));
+  return relative === "" || Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+async function exists(filePath) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function requiredArg(value, name) {
+  if (!value) {
+    fail(`缺少必要参数 --${name}`);
+  }
+
+  return value;
+}
+
+function fail(message) {
+  console.error(message);
+  console.error("使用 --help 查看示例。");
+  process.exit(1);
+}
+
+function trimTrailingSlash(value) {
+  return String(value).replace(/\/+$/, "");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function printHelp() {
+  console.log(`
+批量图生图上色工具
+
+用法:
+  node scripts/batch-colorize.mjs --input ./input --output ./output --token YOUR_SESSION_ID
+
+常用参数:
+  --input <dir>                 输入图片文件夹，必填
+  --output <dir>                输出文件夹，默认: <input>/colorized
+  --token <sessionid>           即梦 sessionid，也可用环境变量 JIMENG_SESSION_ID
+  --api <url>                   jimeng-api 地址，默认: http://localhost:5100
+  --prompt <text>               上色提示词
+  --model <name>                模型，默认: jimeng-4.5
+  --ratio <ratio>               输出比例，默认: 1:1
+  --resolution <level>          分辨率，默认: 2k
+  --sample-strength <number>    图生图强度，默认: 0.5
+  --negative-prompt <text>      负面提示词
+  --intelligent-ratio           启用智能比例
+  --recursive                   递归读取子目录
+  --overwrite                   覆盖已存在输出文件
+  --delay <ms>                  每张图片之间等待毫秒数
+  --continue-on-error <bool>    单张失败后继续，默认: true
+
+示例:
+  node scripts/batch-colorize.mjs --input ./linearts --output ./colored --token us-YOUR_SESSION_ID --recursive --resolution 2k
+`);
+}

--- a/src/api/routes/batch-colorize.ts
+++ b/src/api/routes/batch-colorize.ts
@@ -1,0 +1,115 @@
+import path from "path";
+import { promises as fs } from "fs";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import _ from "lodash";
+
+import Request from "@/lib/request/Request.ts";
+import Response from "@/lib/response/Response.ts";
+import {
+  cancelBatchColorizeJob,
+  createBatchColorizeJob,
+  getBatchColorizeJob,
+} from "@/lib/batch-colorize.ts";
+
+const pagePath = path.join(process.cwd(), "public", "batch-colorize.html");
+const execFileAsync = promisify(execFile);
+
+export default {
+  get: {
+    "/batch-colorize": async () => {
+      const html = await fs.readFile(pagePath, "utf8");
+      return new Response(html, { type: "html" });
+    },
+
+    "/v1/batch-colorize/jobs/:jobId": async (request: Request) => {
+      const job = getBatchColorizeJob(request.params.jobId);
+      if (!job) {
+        throw new Error("Batch job not found");
+      }
+      return job;
+    },
+  },
+
+  post: {
+    "/v1/batch-colorize/jobs": async (request: Request) => {
+      request
+        .validate("body.inputDir", _.isString)
+        .validate("body.token", _.isString);
+
+      return await createBatchColorizeJob({
+        inputDir: request.body.inputDir,
+        outputDir: request.body.outputDir,
+        token: request.body.token,
+        model: request.body.model,
+        prompt: request.body.prompt,
+        ratio: request.body.ratio,
+        resolution: request.body.resolution,
+        sampleStrength: request.body.sampleStrength,
+        negativePrompt: request.body.negativePrompt,
+        intelligentRatio: request.body.intelligentRatio,
+        recursive: request.body.recursive,
+        overwrite: request.body.overwrite,
+        continueOnError: request.body.continueOnError,
+        delayMs: request.body.delayMs,
+      });
+    },
+
+    "/v1/batch-colorize/jobs/:jobId/cancel": async (request: Request) => {
+      const job = cancelBatchColorizeJob(request.params.jobId);
+      if (!job) {
+        throw new Error("Batch job not found");
+      }
+      return job;
+    },
+
+    "/v1/batch-colorize/select-directory": async (request: Request) => {
+      const title = request.body?.title || "选择文件夹";
+      const directory = await selectDirectory(title);
+      return { directory };
+    },
+  },
+};
+
+async function selectDirectory(title: string) {
+  if (process.platform !== "win32") {
+    throw new Error("目录选择弹窗当前仅支持 Windows。请手动输入目录路径。");
+  }
+
+  const safeTitle = String(title).replace(/'/g, "''");
+  const script = `
+Add-Type -AssemblyName System.Windows.Forms
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$dialog = New-Object System.Windows.Forms.FolderBrowserDialog
+$dialog.Description = '${safeTitle}'
+$dialog.ShowNewFolderButton = $true
+$result = $dialog.ShowDialog()
+if ($result -eq [System.Windows.Forms.DialogResult]::OK) {
+  Write-Output $dialog.SelectedPath
+  exit 0
+}
+exit 2
+`;
+
+  try {
+    const { stdout } = await execFileAsync("powershell.exe", [
+      "-NoProfile",
+      "-STA",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      script,
+    ], { windowsHide: false });
+
+    const directory = stdout.trim();
+    if (!directory) {
+      throw new Error("未选择目录。");
+    }
+    return directory;
+  } catch (error) {
+    if (error?.code === 2) {
+      throw new Error("已取消选择目录。");
+    }
+    throw error;
+  }
+}

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -4,6 +4,7 @@ import ping from "./ping.ts";
 import token from './token.js';
 import models from './models.ts';
 import videos from './videos.ts';
+import batchColorize from './batch-colorize.ts';
 
 export default [
     {
@@ -18,6 +19,7 @@ export default [
                     endpoints: {
                         images: '/v1/images/generations',
                         compositions: '/v1/images/compositions',
+                        batchColorize: '/batch-colorize',
                         videos: '/v1/videos/generations',
                         models: '/v1/models',
                         health: '/ping'
@@ -30,5 +32,6 @@ export default [
     ping,
     token,
     models,
-    videos
+    videos,
+    batchColorize
 ];

--- a/src/lib/batch-colorize.ts
+++ b/src/lib/batch-colorize.ts
@@ -1,0 +1,329 @@
+import path from "path";
+import { promises as fs } from "fs";
+
+import axios from "axios";
+
+import util from "@/lib/util.ts";
+import logger from "@/lib/logger.ts";
+import { generateImageComposition } from "@/api/controllers/images.ts";
+import { DEFAULT_IMAGE_MODEL } from "@/api/consts/common.ts";
+
+const IMAGE_EXTENSIONS = new Set([
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".bmp",
+  ".gif",
+  ".tif",
+  ".tiff",
+]);
+
+const DEFAULT_COLORIZE_PROMPT =
+  "请为这张图片进行专业上色，保持原始构图、线条、人物和细节不变，补充自然协调的色彩、光影和材质，画面干净，高质量。";
+
+export type BatchStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
+export type BatchItemStatus = "queued" | "running" | "success" | "failed" | "skipped";
+
+export interface BatchOptions {
+  inputDir: string;
+  outputDir?: string;
+  token: string;
+  model?: string;
+  prompt?: string;
+  ratio?: string;
+  resolution?: string;
+  sampleStrength?: number;
+  negativePrompt?: string;
+  intelligentRatio?: boolean;
+  recursive?: boolean;
+  overwrite?: boolean;
+  continueOnError?: boolean;
+  delayMs?: number;
+}
+
+export interface BatchItem {
+  input: string;
+  status: BatchItemStatus;
+  urls: string[];
+  outputs: string[];
+  error?: string;
+}
+
+export interface BatchJob {
+  id: string;
+  status: BatchStatus;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  options: Omit<BatchOptions, "token"> & { outputDir: string };
+  total: number;
+  current: number;
+  success: number;
+  failed: number;
+  skipped: number;
+  cancelled: boolean;
+  error?: string;
+  reportPath?: string;
+  items: BatchItem[];
+  logs: string[];
+}
+
+const jobs = new Map<string, BatchJob>();
+
+export async function createBatchColorizeJob(options: BatchOptions): Promise<BatchJob> {
+  if (!options.inputDir) {
+    throw new Error("inputDir is required");
+  }
+  if (!options.token) {
+    throw new Error("token is required");
+  }
+
+  const inputDir = path.resolve(options.inputDir);
+  const outputDir = path.resolve(options.outputDir || path.join(inputDir, "colorized"));
+  const recursive = Boolean(options.recursive);
+  const files = await listImages(inputDir, recursive, outputDir);
+
+  if (files.length === 0) {
+    throw new Error(`No images found in ${inputDir}`);
+  }
+
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const job: BatchJob = {
+    id: util.uuid(false),
+    status: "queued",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    options: {
+      inputDir,
+      outputDir,
+      model: options.model || DEFAULT_IMAGE_MODEL,
+      prompt: options.prompt || DEFAULT_COLORIZE_PROMPT,
+      ratio: options.ratio || "1:1",
+      resolution: options.resolution || "2k",
+      sampleStrength: Number.isFinite(Number(options.sampleStrength)) ? Number(options.sampleStrength) : 0.5,
+      negativePrompt: options.negativePrompt || "",
+      intelligentRatio: Boolean(options.intelligentRatio),
+      recursive,
+      overwrite: Boolean(options.overwrite),
+      continueOnError: options.continueOnError !== false,
+      delayMs: Number.isFinite(Number(options.delayMs)) ? Math.max(0, Number(options.delayMs)) : 0,
+    },
+    total: files.length,
+    current: 0,
+    success: 0,
+    failed: 0,
+    skipped: 0,
+    cancelled: false,
+    items: files.map((file) => ({
+      input: file,
+      status: "queued",
+      urls: [],
+      outputs: [],
+    })),
+    logs: [],
+  };
+
+  jobs.set(job.id, job);
+  runBatch(job, options.token).catch((error) => {
+    job.status = "failed";
+    job.error = error.message;
+    addLog(job, `任务失败: ${error.message}`);
+    touch(job);
+  });
+
+  return sanitizeJob(job);
+}
+
+export function getBatchColorizeJob(jobId: string): BatchJob | undefined {
+  const job = jobs.get(jobId);
+  return job ? sanitizeJob(job) : undefined;
+}
+
+export function cancelBatchColorizeJob(jobId: string): BatchJob | undefined {
+  const job = jobs.get(jobId);
+  if (!job) return undefined;
+  job.cancelled = true;
+  if (job.status === "queued") {
+    job.status = "cancelled";
+  }
+  addLog(job, "已请求停止，当前图片完成后将停止。");
+  touch(job);
+  return sanitizeJob(job);
+}
+
+async function runBatch(job: BatchJob, token: string) {
+  job.status = "running";
+  job.startedAt = new Date().toISOString();
+  addLog(job, `发现 ${job.total} 张图片，开始批量上色。`);
+
+  for (let index = 0; index < job.items.length; index++) {
+    if (job.cancelled) {
+      job.status = "cancelled";
+      addLog(job, "任务已停止。");
+      break;
+    }
+
+    const item = job.items[index];
+    job.current = index + 1;
+    item.status = "running";
+    addLog(job, `[${job.current}/${job.total}] 开始处理 ${path.basename(item.input)}`);
+
+    try {
+      const outputPaths = await getPlannedOutputPaths(job, item.input, [".webp"]);
+      if (!job.options.overwrite && outputPaths.length > 0 && await exists(outputPaths[0])) {
+        item.status = "skipped";
+        item.outputs = outputPaths;
+        job.skipped += 1;
+        addLog(job, `跳过已存在结果: ${outputPaths[0]}`);
+        continue;
+      }
+
+      const buffer = await fs.readFile(item.input);
+      const urls = await generateImageComposition(
+        job.options.model || DEFAULT_IMAGE_MODEL,
+        job.options.prompt || DEFAULT_COLORIZE_PROMPT,
+        [buffer],
+        {
+          ratio: job.options.ratio,
+          resolution: job.options.resolution,
+          sampleStrength: job.options.sampleStrength,
+          negativePrompt: job.options.negativePrompt,
+          intelligentRatio: job.options.intelligentRatio,
+        },
+        token,
+      );
+
+      item.urls = urls;
+      item.outputs = [];
+      for (let resultIndex = 0; resultIndex < urls.length; resultIndex++) {
+        const outputPath = await getOutputPath(job, item.input, urls[resultIndex], resultIndex);
+        await downloadImage(urls[resultIndex], outputPath);
+        item.outputs.push(outputPath);
+      }
+
+      item.status = "success";
+      job.success += 1;
+      addLog(job, `完成 ${path.basename(item.input)}，保存 ${item.outputs.length} 个结果。`);
+    } catch (error) {
+      item.status = "failed";
+      item.error = error.message;
+      job.failed += 1;
+      addLog(job, `失败 ${path.basename(item.input)}: ${error.message}`);
+      logger.error(error);
+      if (!job.options.continueOnError) {
+        job.status = "failed";
+        job.error = error.message;
+        break;
+      }
+    } finally {
+      touch(job);
+    }
+
+    if (job.options.delayMs && index < job.items.length - 1) {
+      await sleep(job.options.delayMs);
+    }
+  }
+
+  if (job.status === "running") {
+    job.status = job.failed > 0 ? "failed" : "completed";
+  }
+
+  job.finishedAt = new Date().toISOString();
+  job.reportPath = await writeReport(job);
+  addLog(job, `批处理结束。报告: ${job.reportPath}`);
+  touch(job);
+}
+
+async function listImages(dir: string, recursive: boolean, outputDir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (isSameOrInside(fullPath, outputDir)) continue;
+      if (recursive) {
+        files.push(...await listImages(fullPath, true, outputDir));
+      }
+      continue;
+    }
+
+    if (entry.isFile() && IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      files.push(fullPath);
+    }
+  }
+
+  return files.sort((a, b) => a.localeCompare(b, "zh-Hans-CN"));
+}
+
+async function getPlannedOutputPaths(job: BatchJob, inputPath: string, extensions: string[]) {
+  return Promise.all(extensions.map((extension, index) => getOutputPath(job, inputPath, extension, index)));
+}
+
+async function getOutputPath(job: BatchJob, inputPath: string, urlOrExtension: string, resultIndex: number) {
+  const relativeInput = path.relative(job.options.inputDir, inputPath);
+  const parsed = path.parse(relativeInput);
+  const resultSuffix = resultIndex === 0 ? "" : `_${String(resultIndex + 1).padStart(2, "0")}`;
+  const extension = urlOrExtension.startsWith(".") ? urlOrExtension : getExtensionFromUrl(urlOrExtension) || ".webp";
+  const outputDir = path.join(job.options.outputDir, parsed.dir);
+
+  await fs.mkdir(outputDir, { recursive: true });
+  return path.join(outputDir, `${parsed.name}_colorized${resultSuffix}${extension}`);
+}
+
+async function downloadImage(url: string, outputPath: string) {
+  const response = await axios.get(url, { responseType: "arraybuffer" });
+  await fs.writeFile(outputPath, Buffer.from(response.data));
+}
+
+async function writeReport(job: BatchJob) {
+  const reportPath = path.join(job.options.outputDir, "batch-colorize-report.json");
+  await fs.writeFile(reportPath, JSON.stringify(sanitizeJob(job), null, 2), "utf8");
+  return reportPath;
+}
+
+async function exists(filePath: string) {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function addLog(job: BatchJob, message: string) {
+  job.logs.push(`[${new Date().toLocaleString()}] ${message}`);
+  if (job.logs.length > 300) {
+    job.logs = job.logs.slice(-300);
+  }
+  touch(job);
+}
+
+function sanitizeJob(job: BatchJob): BatchJob {
+  return JSON.parse(JSON.stringify(job));
+}
+
+function touch(job: BatchJob) {
+  job.updatedAt = new Date().toISOString();
+}
+
+function getExtensionFromUrl(value: string) {
+  try {
+    const ext = path.extname(new URL(value).pathname).toLowerCase();
+    return ext && ext.length <= 6 ? ext : "";
+  } catch {
+    return "";
+  }
+}
+
+function isSameOrInside(candidate: string, parent: string) {
+  const relative = path.relative(path.resolve(parent), path.resolve(candidate));
+  return relative === "" || Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- Add a browser UI for batch image-to-image colorization
- Add background batch job APIs with progress, cancellation, logs, and report output
- Add CLI batch colorize helper and Docker public asset copy

## Verification
- npm run build
- Opened http://127.0.0.1:5100/batch-colorize successfully